### PR TITLE
Fix broken link to compound state page

### DIFF
--- a/_glossary/self-transition.md
+++ b/_glossary/self-transition.md
@@ -15,7 +15,7 @@ A transition from the state to itself is depicted as a segment of a circle:
 
 It is important to note that self transitions (or transitions to own child states) will in fact _exit_ the state in which the transition starts.  This is important to keep in mind and can be a source of confusion, since it leads to the _exit_ and _entry_ actions of the state to be re-executed.
 
-For [compound states](compound-states.html){:.glossary} this means that all substates are exited, and any [initial states](initial.state.html){:.glossary} are entered. 
+For [compound states](compound-state.html){:.glossary} this means that all substates are exited, and any [initial states](initial.state.html){:.glossary} are entered. 
 
 ## xstate
 


### PR DESCRIPTION
Fixes broken link to https://statecharts.github.io/glossary/compound-state.html